### PR TITLE
Missing bracket in plain text example.

### DIFF
--- a/docs/en/cowboy/HEAD/guide/resp/index.html
+++ b/docs/en/cowboy/HEAD/guide/resp/index.html
@@ -105,7 +105,7 @@
 <p>Finally, you can also send a body with the response. Cowboy will automatically set the content-length header if you do. We recommend that you set the content-type header so the client may know how to read the body.</p>
 <script type="syntaxhighlighter" class="brush: erlang"><![CDATA[
 {ok, Req2} = cowboy_req:reply(200, [
-    {<<"content-type">>, <<"text/plain">>
+    {<<"content-type">>, <<"text/plain">>}
 ], "Hello world!", Req).
 ]]></script>
 <p>Here is the same example but sending HTML this time.</p>


### PR DESCRIPTION
Minor typo, missing bracket in example doc, I think its in the right place now.
