### PR TITLE
Fix overflow in company description in Firefox.

### DIFF
--- a/css/99s.css
+++ b/css/99s.css
@@ -241,7 +241,6 @@ a.code:hover {
 #company-description p {
     background: url("../img/header_line.png") repeat-x scroll center center transparent;
     color: #333333;
-    font-family: Georgia;
     font-size: 18px;
     font-style: italic;
     line-height: 1.3em;


### PR DESCRIPTION
There is an overflow due to different font rendering in Firefox. as can be seen in the following image
![ninenines_font_problem](https://cloud.githubusercontent.com/assets/711517/4262939/931d57b4-3bc2-11e4-97d0-7593a8fa0ccc.png).

This PR fixes the problem, and additionally causes the font to match everything else on the page.
