### PR TITLE
Update static files page on "User Guide"

### DIFF
--- a/docs/en/cowboy/2.6/guide/static_files/index.html
+++ b/docs/en/cowboy/2.6/guide/static_files/index.html
@@ -83,8 +83,8 @@ http://www.gnu.org/software/src-highlite -->
 </div></div>
 <h2 id="_serve_all_files_from_a_directory">Serve all files from a directory</h2>
 <p>You can also use the static handler to serve all files that can be found in the configured directory. The handler will use the <code>path_info</code> information to resolve the file location, which means that your route must end with a <code>[...]</code> pattern for it to work. All files are served, including the ones that may be found in subfolders.</p>
-<p>You can specify the directory relative to an application&apos;s private directory.</p>
-<p>The following rule will serve any file found in the application <code>my_app</code>&apos;s priv directory inside the <code>static/assets</code> folder whenever the requested path begins with <code>/assets/</code>:</p>
+<p>You can specify the directory relative to the application&apos;s private directory (e.g. my_app/priv).</p>
+<p>The following rule will serve any file found in the application <code>my_app/priv</code> directory inside the <code>static/assets</code> folder whenever the requested path begins with <code>/assets/</code>:</p>
 <div class="listingblock"><div class="content"><!-- Generator: GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it


### PR DESCRIPTION
Provides a slightly more detailed example on how the "private" directory should be named ("priv") in order to make the static handler find it properly. I just realized that looking in the [`file_server` example.](https://github.com/ninenines/cowboy/tree/master/examples/file_server).